### PR TITLE
Fix bug in BoltHandler.Modify

### DIFF
--- a/calltable.go
+++ b/calltable.go
@@ -6,17 +6,16 @@ import (
 	"strings"
 
 	bolt "github.com/coreos/bbolt"
-	"github.com/imdario/mergo"
 	"github.com/ktnyt/imascg/rest"
 )
 
 // Calltable is the model for calltable
 type Calltable struct {
 	ID     string   `json:"id"`
-	Caller *string  `json:"caller"`
-	Callee *string  `json:"callee"`
-	Called *string  `json:"called"`
-	Remark *string  `json:"remark"`
+	Caller *string  `json:"caller, omitempty"`
+	Callee *string  `json:"callee, omitempty"`
+	Called *string  `json:"called, omitempty"`
+	Remark *string  `json:"remark, omitempty"`
 	DB     *bolt.DB `json:"-"`
 }
 
@@ -109,20 +108,18 @@ func (c *Calltable) Filter(values url.Values) bool {
 
 // Merge another calltable entry into this calltable entry
 func (c *Calltable) Merge(m rest.Model) error {
-	return mergo.MergeWithOverwrite(c, m)
-}
-
-// Clone the calltable entry instance
-func (c *Calltable) Clone() rest.Model {
-	caller := *c.Caller
-	callee := *c.Callee
-	called := *c.Called
-	remark := *c.Remark
-	return &Calltable{
-		ID:     c.ID,
-		Caller: &caller,
-		Callee: &callee,
-		Called: &called,
-		Remark: &remark,
+	other := m.(*Calltable)
+	if other.Caller != nil {
+		c.Caller = other.Caller
 	}
+	if other.Callee != nil {
+		c.Callee = other.Callee
+	}
+	if other.Called != nil {
+		c.Called = other.Called
+	}
+	if other.Remark != nil {
+		c.Remark = other.Remark
+	}
+	return nil
 }

--- a/characters.go
+++ b/characters.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/imdario/mergo"
 	"github.com/ktnyt/imascg/rest"
 )
 
@@ -66,22 +65,15 @@ func (c *Character) Filter(values url.Values) bool {
 
 // Merge another character into this character
 func (c *Character) Merge(m rest.Model) error {
-	return mergo.MergeWithOverwrite(c, m)
-}
-
-// Clone the character instance
-func (c *Character) Clone() rest.Model {
-	n := *c.Name
-	t := *c.Type
-	r := make([]string, len(c.Readings))
-	for i := range c.Readings {
-		r[i] = c.Readings[i]
+	other := m.(*Character)
+	if other.Name != nil {
+		c.Name = other.Name
 	}
-
-	return &Character{
-		ID:       c.ID,
-		Name:     &n,
-		Type:     &t,
-		Readings: r,
+	if other.Type != nil {
+		c.Type = other.Type
 	}
+	if other.Readings != nil {
+		c.Readings = other.Readings
+	}
+	return nil
 }

--- a/cmd/imascg/calltable.go
+++ b/cmd/imascg/calltable.go
@@ -8,10 +8,12 @@ import (
 	"github.com/ktnyt/imascg/rest"
 )
 
-func init() {
-	m := rest.NewJSONModel(&imascg.Calltable{DB: db})
+func newCalltable() rest.MarshalableModel {
+	return rest.NewJSONModel(&imascg.Calltable{DB: db})
+}
 
-	h, err := rest.NewBoltHandler(db, []byte("calltable"), m)
+func init() {
+	h, err := rest.NewBoltHandler(db, []byte("calltable"), newCalltable)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/imascg/characters.go
+++ b/cmd/imascg/characters.go
@@ -7,9 +7,12 @@ import (
 	"github.com/ktnyt/imascg/rest"
 )
 
+func newCharacter() rest.MarshalableModel {
+	return rest.NewJSONModel(&imascg.Character{})
+}
+
 func init() {
-	m := rest.NewJSONModel(&imascg.Character{})
-	h, err := rest.NewBoltHandler(db, []byte("characters"), m)
+	h, err := rest.NewBoltHandler(db, []byte("characters"), newCharacter)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/imascg/units.go
+++ b/cmd/imascg/units.go
@@ -7,9 +7,12 @@ import (
 	"github.com/ktnyt/imascg/rest"
 )
 
+func newUnit() rest.MarshalableModel {
+	return rest.NewJSONModel(&imascg.Unit{})
+}
+
 func init() {
-	m := rest.NewJSONModel(&imascg.Unit{})
-	h, err := rest.NewBoltHandler(db, []byte("units"), m)
+	h, err := rest.NewBoltHandler(db, []byte("units"), newUnit)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/rest/json_model.go
+++ b/rest/json_model.go
@@ -34,7 +34,3 @@ func (j *jsonMarshalable) MarshalJSON() ([]byte, error) {
 func (j *jsonMarshalable) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &j.model)
 }
-
-func (j *jsonMarshalable) Clone() Marshalable {
-	return &jsonMarshalable{model: j.model.Clone()}
-}

--- a/rest/model.go
+++ b/rest/model.go
@@ -8,7 +8,6 @@ type Model interface {
 	MakeKey(uint64) []byte
 	Filter(url.Values) bool
 	Merge(Model) error
-	Clone() Model
 }
 
 // Marshalable defines the interface required for Model marshalling
@@ -19,7 +18,6 @@ type Marshalable interface {
 	Unmarshal([]byte) error
 	MarshalJSON() ([]byte, error)
 	UnmarshalJSON([]byte) error
-	Clone() Marshalable
 }
 
 // MarshalableModel is the integrated type for Model and Marshalable
@@ -65,9 +63,4 @@ func (m *MarshalableModel) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON delegates the call to Marshalable.UnmarshalJSON
 func (m *MarshalableModel) UnmarshalJSON(data []byte) error {
 	return m.m.UnmarshalJSON(data)
-}
-
-// Clone delegates the call to Marshalable.Clone
-func (m *MarshalableModel) Clone() MarshalableModel {
-	return MarshalableModel{m: m.m.Clone()}
 }

--- a/units.go
+++ b/units.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/imdario/mergo"
 	"github.com/ktnyt/imascg/rest"
 	"github.com/satori/go.uuid"
 )
@@ -68,25 +67,15 @@ func (u *Unit) Filter(values url.Values) bool {
 
 // Merge another unit into this unit
 func (u *Unit) Merge(m rest.Model) error {
-	return mergo.MergeWithOverwrite(u, m)
-}
-
-// Clone the unit instance
-func (u *Unit) Clone() rest.Model {
-	n := *u.Name
-	m := make([]string, len(u.Members))
-	for i := range u.Members {
-		m[i] = u.Members[i]
+	other := m.(*Unit)
+	if other.Name != nil {
+		u.Name = other.Name
 	}
-	r := make([]string, len(u.Readings))
-	for i := range u.Readings {
-		r[i] = u.Readings[i]
+	if other.Members != nil {
+		u.Members = other.Members
 	}
-
-	return &Unit{
-		ID:       u.ID,
-		Name:     &n,
-		Members:  m,
-		Readings: r,
+	if other.Readings != nil {
+		u.Readings = other.Readings
 	}
+	return nil
 }


### PR DESCRIPTION
This patch should fix the problem addressed in #21 by altering the application structure.

`BoltHandler` will now have an `instantiate` function which instantiates a model into a `MarshalableModel` which will eliminate the need for the `Clone()` method.